### PR TITLE
discover method should return the current state of all devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ Wemo.prototype.load = function(setupUrl, cb) {
       device.port = location.port;
       device.callbackURL = self.getCallbackURL();
 
-      // Return only matching devices and return them only once!
-      if (!self._clients[device.UDN] && device.deviceType.match(/^urn:Belkin:device/)) {
+      // Return only matching devices
+      if (device.deviceType.match(/^urn:Belkin:device/) {
         debug('Found device: %j', json);
         if (cb) {
           cb.call(self, device);


### PR DESCRIPTION
With the current library there is no way to know when WeMo devices have been removed from the local network. Currently the discover method only returned newly discovered devices.

This change ensures that all devices returned represent the current state of the WeMo devices on the network. Not only is this more accurate but it allows the consumer to understand when devices have been removed from the network.